### PR TITLE
Open links into a new tab in Outline

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,3 +30,19 @@ function findOutlineUrl(currentUrl) {
 }
 
 browser.browserAction.onClicked.addListener(openPage);
+
+browser.contextMenus.create({
+  id: "open-link-in-outline",
+  title: "Open Link in Outline",
+  contexts: ["link"]
+});
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "open-link-in-outline") {
+      findOutlineUrl(info.linkUrl)
+      .then(openOutlineUrl)
+      .catch(function(err) {
+        console.err('Dang, your request failed', err)
+      });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Send to Outline",
-  "version": "1.0.1",
+  "version": "1.1.0",
 
   "description": "Sends the reader to the same article on https://outline.com",
   "icons": {
@@ -21,6 +21,7 @@
   },
 
   "permissions": [
-    "tabs"
+    "tabs",
+    "contextMenus"
   ]
 }


### PR DESCRIPTION
Add a way to right click a link to an article and select "Open Link in Outline" to do so.