### PR TITLE
Shorten URL before hitting Outline.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,8 +36,11 @@ function findCurrentUrl(event) {
   return Promise.resolve(event.url);
 }
 
-function findOutlineUrl(currentUrl) {
-  return Promise.resolve(`https://outline.com/${currentUrl}`)
+async function findOutlineUrl(currentUrl) {
+  const request = await fetch(`https://tinyurl.com/api-create.php?url=${currentUrl}`)
+
+  const shortUrl = await request.text();
+  return `https://outline.com/${shortUrl}`
 }
 
 browser.browserAction.onClicked.addListener(openPage);


### PR DESCRIPTION
Outline.com is blocking a number of URLs. This measure can be bypassed by using URL shorteners.

[Pre-packaged version ZIP here](https://github.com/okhwaja/outline-extension/files/5139056/send_to_outline-1.3.0-an%2Bfx.zip)

This is a self-signed add-on. To install you will need to extract the it from the zip and open it with firefox (or just drag it into firefox).